### PR TITLE
Update default.nix

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -23,6 +23,7 @@
 
   bufferlines.enable = lib.mkDefault true;
   colorschemes.enable = lib.mkDefault true;
+  colorschemes.base16.enable = lib.mkDefault true;
   completion.enable = lib.mkDefault true;
   dap.enable = lib.mkDefault true;
   filetrees.enable = lib.mkDefault false;


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `base16` support to the `colorschemes` configuration.

- Updated `default.nix` to include the new configuration option.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.nix</strong><dd><code>Add `base16` support to `colorschemes` configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/default.nix

<li>Added <code>colorschemes.base16.enable</code> with a default value of <code>true</code>.<br> <li> Enhanced the <code>colorschemes</code> configuration to support <code>base16</code>.


</details>


  </td>
  <td><a href="https://github.com/askusWT/Neve/pull/5/files#diff-f7150810455ddac71aa9bf0feace267f59fdf475f71f6efd12139f7cc5c3560e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>